### PR TITLE
Add support for global preferences and csslint/jshint options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Usage
 If you want to change the default rules place a `.htmlhintrc` and/or `.xmlhintrc` file at the project root.  
 Check the default ruleset [here](https://github.com/yaniswang/HTMLHint/wiki/Usage).
 
+Global default options are available under "Debug > Open Preferences File" by adding or modifying "htmlhint.options" and "xmlhint.options".
+It also uses "jshint.options" and "csslint.options" for script and style tags.
 
 Issues/Updates
 =====

--- a/main.js
+++ b/main.js
@@ -86,12 +86,20 @@ define(function (require) {
     function htmlHinter(text, fullPath) {
         var defaults = htmlDefaults;
         return _loadRules(".jshintrc").then(function (rules) {
-            defaults.jshint = $.extend(true, {}, jsDefaults||{}, rules);
-            if ($.isEmptyObject(defaults.jshint)) defaults.jshint = false;
+            if (!window.JSHINT) {
+                defaults.jshint = false;
+            } else {
+                defaults.jshint = $.extend(true, {}, jsDefaults||{}, rules);
+                if ($.isEmptyObject(defaults.jshint)) defaults.jshint = false;
+            }
             return _loadRules(".csslintrc");
         }).then(function (rules) {
-            defaults.csslint = $.extend(true, {}, cssDefaults||{}, rules);
-            if ($.isEmptyObject(defaults.csslint)) defaults.csslint = false;
+            if (!window.CSSLint) {
+                defaults.csslint = false;
+            } else {
+                defaults.csslint = $.extend(true, {}, cssDefaults||{}, rules);
+                if ($.isEmptyObject(defaults.csslint)) defaults.csslint = false;
+            }
             return _hinter(text, fullPath, ".htmlhintrc", defaults);
         });
     }

--- a/main.js
+++ b/main.js
@@ -36,10 +36,19 @@ define(function (require) {
 
     var jspm = PreferencesManager.getExtensionPrefs("jshint");
     var jsDefaults;
-    jspm.on("change", function () {
+    function _loadJSDefaults() {
         jsDefaults = jspm.get("options");
+        if (jsDefaults) {
+            var globals = jspm.get("globals") || {};
+            jsDefaults.predef = Object.keys(globals).map(function(el) {
+                return globals[el] ? el : '-' + el;
+            });
+        }
+    }
+    jspm.on("change", function () {
+        _loadJSDefaults();
     });
-    jsDefaults = jspm.get("options");
+    _loadJSDefaults();
 
     require("htmlhint/htmlhint");
 

--- a/main.js
+++ b/main.js
@@ -8,12 +8,30 @@ define(function (require) {
     var CodeInspection  = brackets.getModule("language/CodeInspection");
     var LanguageManager = brackets.getModule("language/LanguageManager");
     var ProjectManager  = brackets.getModule("project/ProjectManager");
+    var PreferencesManager = brackets.getModule("preferences/PreferencesManager");
+
+    var htmlpm = PreferencesManager.getExtensionPrefs("htmlhint");
+    var htmlDefaults;
+    htmlpm.definePreference("options", "object", {})
+        .on("change", function () {
+            htmlDefaults = htmlpm.get("options");
+        });
+    htmlDefaults = htmlpm.get("options");
+
+    var xmlpm = PreferencesManager.getExtensionPrefs("xmlhint");
+    var xmlDefaults;
+    xmlpm.definePreference("options", "object", {
+        "doctype-first": false
+    }).on("change", function () {
+        xmlDefaults = xmlpm.get("options");
+    });
+    xmlDefaults = xmlpm.get("options");
 
     require("htmlhint/htmlhint");
 
-    function _hinter(text, fullPath, configFileName) {
+    function _hinter(text, fullPath, configFileName, defaults) {
         return _loadRules(configFileName).then(function (rules) {
-            var results = HTMLHint.verify(text, rules);
+            var results = HTMLHint.verify(text, $.extend({}, defaults, rules));
             if (results.length) {
                 var result = {
                     errors: []
@@ -52,11 +70,11 @@ define(function (require) {
     }
 
     function htmlHinter(text, fullPath) {
-        return _hinter(text, fullPath, ".htmlhintrc");
+        return _hinter(text, fullPath, ".htmlhintrc", htmlDefaults);
     }
 
     function xmlHinter(text, fullPath) {
-        return _hinter(text, fullPath, ".xmlhintrc");
+        return _hinter(text, fullPath, ".xmlhintrc", xmlDefaults);
     }
 
     function _loadRules(configFileName) {

--- a/main.js
+++ b/main.js
@@ -27,11 +27,25 @@ define(function (require) {
     });
     xmlDefaults = xmlpm.get("options");
 
+    var csspm = PreferencesManager.getExtensionPrefs("csslint");
+    var cssDefaults;
+    csspm.on("change", function () {
+        cssDefaults = csspm.get("options");
+    });
+    cssDefaults = csspm.get("options");
+
+    var jspm = PreferencesManager.getExtensionPrefs("jshint");
+    var jsDefaults;
+    jspm.on("change", function () {
+        jsDefaults = jspm.get("options");
+    });
+    jsDefaults = jspm.get("options");
+
     require("htmlhint/htmlhint");
 
     function _hinter(text, fullPath, configFileName, defaults) {
         return _loadRules(configFileName).then(function (rules) {
-            var results = HTMLHint.verify(text, $.extend({}, defaults, rules));
+            var results = HTMLHint.verify(text, $.extend(true, {}, defaults, rules));
             if (results.length) {
                 var result = {
                     errors: []
@@ -70,7 +84,14 @@ define(function (require) {
     }
 
     function htmlHinter(text, fullPath) {
-        return _hinter(text, fullPath, ".htmlhintrc", htmlDefaults);
+        var defaults = htmlDefaults;
+        return _loadRules(".jshintrc").then(function (rules) {
+            defaults.jshint = $.extend(true, {}, jsDefaults||{}, rules);
+            return _loadRules(".csslintrc");
+        }).then(function (rules) {
+            defaults.csslint = $.extend(true, {}, cssDefaults||{}, rules);
+            return _hinter(text, fullPath, ".htmlhintrc", defaults);
+        });
     }
 
     function xmlHinter(text, fullPath) {

--- a/main.js
+++ b/main.js
@@ -87,9 +87,11 @@ define(function (require) {
         var defaults = htmlDefaults;
         return _loadRules(".jshintrc").then(function (rules) {
             defaults.jshint = $.extend(true, {}, jsDefaults||{}, rules);
+            if ($.isEmptyObject(defaults.jshint)) defaults.jshint = false;
             return _loadRules(".csslintrc");
         }).then(function (rules) {
             defaults.csslint = $.extend(true, {}, cssDefaults||{}, rules);
+            if ($.isEmptyObject(defaults.csslint)) defaults.csslint = false;
             return _hinter(text, fullPath, ".htmlhintrc", defaults);
         });
     }


### PR DESCRIPTION
Hi,
I've added support for preference file like I did for your csslint and jshint extensions.
This extension now also looking for the other preferences and ._rc-files, so it checks style and script tags the same way as css and js files.